### PR TITLE
[Feat/#4] 공통 API response 구현

### DIFF
--- a/src/main/java/oasis/piloti/api/ApiResponse.java
+++ b/src/main/java/oasis/piloti/api/ApiResponse.java
@@ -1,0 +1,20 @@
+package oasis.piloti.api;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ApiResponse<T> {
+    private String status;
+    private T data;
+    private String message;
+
+    @Builder
+    public ApiResponse(String status, T data, String message) {
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+}

--- a/src/main/java/oasis/piloti/api/ResponseBuilder.java
+++ b/src/main/java/oasis/piloti/api/ResponseBuilder.java
@@ -1,0 +1,48 @@
+package oasis.piloti.api;
+
+import oasis.piloti.enumerate.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseBuilder {
+
+    private static final Status STATUS_SUCCESS = Status.SUCCESS;
+
+    private static final Status STATUS_FAILURE = Status.FAILURE;
+
+    private static final Status STATUS_ERROR = Status.ERROR;
+
+    private static <T> ResponseEntity<ApiResponse<T>> buildResponseWithData(Status status, T data, String message, HttpStatus httpStatus) {
+        ApiResponse<T> response = ApiResponse.<T>builder()
+                .status(status.getValue())
+                .data(data)
+                .message(message)
+                .build();
+        return new ResponseEntity<>(response, httpStatus);
+    }
+
+    private static <T> ResponseEntity<ApiResponse<T>> buildResponseWithoutData(Status status, String message, HttpStatus httpStatus) {
+        ApiResponse<T> response = ApiResponse.<T>builder()
+                .status(status.getValue())
+                .data(null)
+                .message(message)
+                .build();
+        return new ResponseEntity<>(response, httpStatus);
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> buildSuccessResponseWithData(T data, String message, HttpStatus httpStatus) {
+        return buildResponseWithData(STATUS_SUCCESS, data, message, httpStatus);
+    }
+
+    public static ResponseEntity<ApiResponse<Void>> buildSuccessResponseWithoutData(String message, HttpStatus httpStatus) {
+        return buildResponseWithoutData(STATUS_SUCCESS, message, httpStatus);
+    }
+
+    public static ResponseEntity<ApiResponse<Void>> buildFailureResponse(String message, HttpStatus httpStatus) {
+        return buildResponseWithoutData(STATUS_FAILURE, message, httpStatus);
+    }
+
+    public static ResponseEntity<ApiResponse<Void>> buildErrorResponse(String message, HttpStatus httpStatus) {
+        return buildResponseWithoutData(STATUS_ERROR, message, httpStatus);
+    }
+}

--- a/src/main/java/oasis/piloti/enumerate/Status.java
+++ b/src/main/java/oasis/piloti/enumerate/Status.java
@@ -1,0 +1,15 @@
+package oasis.piloti.enumerate;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Status {
+
+    SUCCESS("success"),
+    FAILURE("failure"),
+    ERROR("error");
+
+    private final String value;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3 

## 📝작업 내용

> ApiResponse 작성
- 공통 응답을 위한 ApiResponse 작성

> Status 작성
- 성공, 실패, 에러를 한곳에서 관리하기 위해 Status enum 작성

> ResponseBuilder 작성
- ApiResponse 를 간편하게 작성하기 위해 ResponseBuilder 작성

## 💬리뷰 요구사항(선택)

> 공통 API response 구현하였습니다. ResponseBuilder의 buildxxx 로 시작하는 메서드를 사용해서 api를 응답해주시면 감사드리겠습니다.
