### PR TITLE
[Feat/#7] 학습 카드 리스트 조회, 학습 카드 조회 기능 구현

### DIFF
--- a/src/main/java/oasis/piloti/controller/StudyCardController.java
+++ b/src/main/java/oasis/piloti/controller/StudyCardController.java
@@ -1,0 +1,38 @@
+package oasis.piloti.controller;
+
+import lombok.RequiredArgsConstructor;
+import oasis.piloti.api.ApiResponse;
+import oasis.piloti.dto.StudyCardResponse;
+import oasis.piloti.service.StudyCardService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static oasis.piloti.api.ResponseBuilder.*;
+
+@RestController
+@RequiredArgsConstructor
+public class StudyCardController {
+
+    private final StudyCardService studyCardService;
+
+    @GetMapping("/api/study-cards")
+    public ResponseEntity<ApiResponse<List<StudyCardResponse.SimpleInfoDTO>>> getStudyCards() {
+
+        List<StudyCardResponse.SimpleInfoDTO> studyCards = studyCardService.getStudyCards();
+
+        return buildSuccessResponseWithData(studyCards, "학습 카드 리스트 조회를 성공하였습니다.", HttpStatus.OK);
+    }
+
+    @GetMapping("/api/study-card/{studyCardId}")
+    public ResponseEntity<ApiResponse<StudyCardResponse.InfoDTO>> getStudyCard(@PathVariable Long studyCardId) {
+
+        StudyCardResponse.InfoDTO studyCard = studyCardService.getStudyCard(studyCardId);
+
+        return buildSuccessResponseWithData(studyCard, "학습 카드 조회를 성공하였습니다.", HttpStatus.OK);
+    }
+}

--- a/src/main/java/oasis/piloti/dto/StudyCardResponse.java
+++ b/src/main/java/oasis/piloti/dto/StudyCardResponse.java
@@ -1,0 +1,123 @@
+package oasis.piloti.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import oasis.piloti.entity.Dialogue;
+import oasis.piloti.entity.StudyCard;
+import oasis.piloti.entity.Word;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StudyCardResponse {
+
+    @Getter
+    @NoArgsConstructor
+    public static class SimpleInfoDTO {
+
+        private String koreanTitle;
+        private String russianTitle;
+        private String koreanDescription;
+        private String russianDescription;
+
+        @Builder
+        public SimpleInfoDTO(String koreanTitle, String russianTitle, String koreanDescription, String russianDescription) {
+            this.koreanTitle = koreanTitle;
+            this.russianTitle = russianTitle;
+            this.koreanDescription = koreanDescription;
+            this.russianDescription = russianDescription;
+        }
+
+        public static SimpleInfoDTO fromEntity(StudyCard studyCard) {
+            return SimpleInfoDTO.builder()
+                    .koreanTitle(studyCard.getKoreanTitle())
+                    .russianTitle(studyCard.getRussianTitle())
+                    .koreanDescription(studyCard.getKoreanDescription())
+                    .russianDescription(studyCard.getRussianDescription())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class InfoDTO {
+        private String koreanTitle;
+        private String russianTitle;
+        private String koreanDescription;
+        private String russianDescription;
+        private List<WordDTO> words;
+        private List<DialogueDTO> dialogues;
+
+        @Builder
+        public InfoDTO(String koreanTitle, String russianTitle, String koreanDescription, String russianDescription, List<WordDTO> words, List<DialogueDTO> dialogues) {
+            this.koreanTitle = koreanTitle;
+            this.russianTitle = russianTitle;
+            this.koreanDescription = koreanDescription;
+            this.russianDescription = russianDescription;
+            this.words = words;
+            this.dialogues = dialogues;
+        }
+
+        public static InfoDTO fromEntity(StudyCard studyCard) {
+            return InfoDTO.builder()
+                    .koreanTitle(studyCard.getKoreanTitle())
+                    .russianTitle(studyCard.getRussianTitle())
+                    .koreanDescription(studyCard.getKoreanDescription())
+                    .russianDescription(studyCard.getRussianDescription())
+                    .words(studyCard.getWords().stream()
+                            .map(WordDTO::fromEntity)
+                            .collect(Collectors.toList()))
+                    .dialogues(studyCard.getDialogues().stream()
+                            .map(DialogueDTO::fromEntity)
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class WordDTO {
+        private String koreanWord;
+        private String russianWord;
+        private String audioUrl;
+
+        @Builder
+        public WordDTO(String koreanWord, String russianWord, String audioUrl) {
+            this.koreanWord = koreanWord;
+            this.russianWord = russianWord;
+            this.audioUrl = audioUrl;
+        }
+
+        public static WordDTO fromEntity(Word word) {
+            return WordDTO.builder()
+                    .koreanWord(word.getKoreanWord())
+                    .russianWord(word.getRussianWord())
+                    .audioUrl(word.getAudioUrl())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class DialogueDTO {
+        private String koreanSentence;
+        private String russianSentence;
+        private String audioUrl;
+
+        @Builder
+        public DialogueDTO(String koreanSentence, String russianSentence, String audioUrl) {
+            this.koreanSentence = koreanSentence;
+            this.russianSentence = russianSentence;
+            this.audioUrl = audioUrl;
+        }
+
+        public static DialogueDTO fromEntity(Dialogue dialogue) {
+            return DialogueDTO.builder()
+                    .koreanSentence(dialogue.getKoreanSentence())
+                    .russianSentence(dialogue.getRussianSentence())
+                    .audioUrl(dialogue.getAudioUrl())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/oasis/piloti/entity/Dialogue.java
+++ b/src/main/java/oasis/piloti/entity/Dialogue.java
@@ -16,10 +16,10 @@ public class Dialogue {
     private Long id;
 
     @Column(nullable = false)
-    private String koreanText; // 한국 문장
+    private String koreanSentence; // 한국 문장
 
     @Column(nullable = false)
-    private String russianText; // 러시아 문장
+    private String russianSentence; // 러시아 문장
 
     @Column(nullable = false)
     private String audioUrl; // 음성 주소
@@ -35,18 +35,18 @@ public class Dialogue {
     private IncorrectDialogue incorrectDialogue;
 
     @Builder
-    private Dialogue(String koreanText, String russianText, String audioUrl, StudyCard studyCard) {
-        this.koreanText = koreanText;
-        this.russianText = russianText;
+    private Dialogue(String koreanSentence, String russianSentence, String audioUrl, StudyCard studyCard) {
+        this.koreanSentence = koreanSentence;
+        this.russianSentence = russianSentence;
         this.audioUrl = audioUrl;
         assignStudyCard(studyCard);
     }
 
     // 직접 빌더 패턴의 생성자를 활용하지 말고 해당 메서드를 활용하여 엔티티 생성
-    public static Dialogue buildDialogue(String koreanText, String russianText, String audioUrl, StudyCard studyCard) {
+    public static Dialogue buildDialogue(String koreanSentence, String russianSentence, String audioUrl, StudyCard studyCard) {
         return Dialogue.builder()
-                .koreanText(koreanText)
-                .russianText(russianText)
+                .koreanSentence(koreanSentence)
+                .russianSentence(russianSentence)
                 .audioUrl(audioUrl)
                 .studyCard(studyCard)
                 .build();

--- a/src/main/java/oasis/piloti/entity/StudyCard.java
+++ b/src/main/java/oasis/piloti/entity/StudyCard.java
@@ -19,30 +19,44 @@ public class StudyCard {
     private Long id;
 
     @Column(nullable = false)
-    private String title; // 제목
+    private String koreanTitle; // 한국 제목
 
     @Column(nullable = false)
-    private String description; // 설명
+    private String russianTitle; // 러시아 제목
+
+    @Column(nullable = false)
+    private String koreanDescription; // 한국 설명
+
+    @Column(nullable = false)
+    private String russianDescription; // 러시아 설명
 
     // 양방향 연관관계
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "studyCard")
     private List<Dialogue> dialogues = new ArrayList<>();
 
     // 양방향 연관관계
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "studyCard")
+    private List<Word> words = new ArrayList<>();
+
+    // 양방향 연관관계
     @OneToOne(mappedBy = "studyCard")
     private ReviewCard reviewCard;
 
     @Builder
-    private StudyCard(String title, String description) {
-        this.title = title;
-        this.description = description;
+    public StudyCard(String koreanTitle, String russianTitle, String koreanDescription, String russianDescription) {
+        this.koreanTitle = koreanTitle;
+        this.russianTitle = russianTitle;
+        this.koreanDescription = koreanDescription;
+        this.russianDescription = russianDescription;
     }
 
     // 직접 빌더 패턴의 생성자를 활용하지 말고 해당 메서드를 활용하여 엔티티 생성
-    public static StudyCard buildStudyCard(String title, String description) {
+    public static StudyCard buildStudyCard(String koreanTitle, String russianTitle, String koreanDescription, String russianDescription) {
         return StudyCard.builder()
-                .title(title)
-                .description(description)
+                .koreanTitle(koreanTitle)
+                .russianTitle(russianTitle)
+                .koreanDescription(koreanDescription)
+                .russianDescription(russianDescription)
                 .build();
     }
 
@@ -67,6 +81,16 @@ public class StudyCard {
 
         if (dialogue.getStudyCard() != this) {
             dialogue.assignStudyCard(this);
+        }
+    }
+
+    // StudyCard 1 <-> Word N
+    // 양방향 연관관계 편의 메서드
+    public void addWord(Word word) {
+        this.words.add(word);
+
+        if (word.getStudyCard() != this) {
+            word.assignStudyCard(this);
         }
     }
 }

--- a/src/main/java/oasis/piloti/entity/Word.java
+++ b/src/main/java/oasis/piloti/entity/Word.java
@@ -1,0 +1,64 @@
+package oasis.piloti.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Word {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String koreanWord; // 한국 단어
+
+    @Column(nullable = false)
+    private String russianWord; // 러시아 문장
+
+    @Column(nullable = false)
+    private String audioUrl; // 음성 주소
+
+    // 연관관계 주인
+    // 양방향 연관관계
+    @ManyToOne
+    @JoinColumn(name = "study_card_id")
+    private StudyCard studyCard;
+
+    @Builder
+    private Word(String koreanWord, String russianWord, String audioUrl, StudyCard studyCard) {
+        this.koreanWord = koreanWord;
+        this.russianWord = russianWord;
+        this.audioUrl = audioUrl;
+        assignStudyCard(studyCard);
+    }
+
+    // 직접 빌더 패턴의 생성자를 활용하지 말고 해당 메서드를 활용하여 엔티티 생성
+    public static Word buildWord(String koreanWord, String russianWord, String audioUrl, StudyCard studyCard) {
+        return Word.builder()
+                .koreanWord(koreanWord)
+                .russianWord(russianWord)
+                .audioUrl(audioUrl)
+                .studyCard(studyCard)
+                .build();
+    }
+
+    // Word N <-> StudyCard 1
+    // 양방향 연관관계 편의 메서드
+    public void assignStudyCard(StudyCard studyCard) {
+        if (this.studyCard != null) {
+            this.studyCard.getWords().remove(this);
+        }
+
+        this.studyCard = studyCard;
+
+        if (!studyCard.getWords().contains(this)) {
+            studyCard.addWord(this);
+        }
+    }
+}

--- a/src/main/java/oasis/piloti/initializer/DataInitializer.java
+++ b/src/main/java/oasis/piloti/initializer/DataInitializer.java
@@ -1,0 +1,48 @@
+package oasis.piloti.initializer;
+
+import lombok.RequiredArgsConstructor;
+import oasis.piloti.entity.Dialogue;
+import oasis.piloti.entity.StudyCard;
+import oasis.piloti.entity.Word;
+import oasis.piloti.repository.DialogueRepository;
+import oasis.piloti.repository.StudyCardRepository;
+import oasis.piloti.repository.WordRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final StudyCardRepository studyCardRepository;
+    private final WordRepository wordRepository;
+    private final DialogueRepository dialogueRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+
+        for (int i = 1; i <= 3; i++) {
+            StudyCard studyCard = StudyCard.buildStudyCard(
+                    "한국어 제목 " + i,
+                    "러시아어 제목 " + i,
+                    "한국어 설명 " + i,
+                    "러시아어 설명 " + i
+            );
+
+            studyCardRepository.save(studyCard);
+
+            // 단어 예시 추가
+            Word word1 = Word.buildWord("한국어 단어 " + i, "러시아어 단어 " + i, "https://example.com/audio" + i + ".mp3", studyCard);
+            Word word2 = Word.buildWord("한국어 단어 " + (i+1), "러시아어 단어 " + (i+1), "https://example.com/audio" + (i+1) + ".mp3", studyCard);
+            wordRepository.save(word1);
+            wordRepository.save(word2);
+
+
+            // 문장 예시 추가
+            Dialogue dialogue1 = Dialogue.buildDialogue("한국어 문장 " + i, "러시아어 문장 " + i, "https://example.com/audio" + i + ".mp3", studyCard);
+            Dialogue dialogue2 = Dialogue.buildDialogue("한국어 문장 " + (i+1), "러시아어 문장 " + (i+1), "https://example.com/audio" + (i+1) + ".mp3", studyCard);
+            dialogueRepository.save(dialogue1);
+            dialogueRepository.save(dialogue2);
+        }
+    }
+}

--- a/src/main/java/oasis/piloti/repository/DialogueRepository.java
+++ b/src/main/java/oasis/piloti/repository/DialogueRepository.java
@@ -1,0 +1,9 @@
+package oasis.piloti.repository;
+
+import oasis.piloti.entity.Dialogue;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DialogueRepository extends JpaRepository<Dialogue, Long> {
+}

--- a/src/main/java/oasis/piloti/repository/StudyCardRepository.java
+++ b/src/main/java/oasis/piloti/repository/StudyCardRepository.java
@@ -1,0 +1,9 @@
+package oasis.piloti.repository;
+
+import oasis.piloti.entity.StudyCard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyCardRepository extends JpaRepository<StudyCard, Long> {
+}

--- a/src/main/java/oasis/piloti/repository/WordRepository.java
+++ b/src/main/java/oasis/piloti/repository/WordRepository.java
@@ -1,0 +1,9 @@
+package oasis.piloti.repository;
+
+import oasis.piloti.entity.Word;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WordRepository extends JpaRepository<Word, Long> {
+}

--- a/src/main/java/oasis/piloti/service/StudyCardService.java
+++ b/src/main/java/oasis/piloti/service/StudyCardService.java
@@ -1,0 +1,31 @@
+package oasis.piloti.service;
+
+import lombok.RequiredArgsConstructor;
+import oasis.piloti.dto.StudyCardResponse;
+import oasis.piloti.entity.StudyCard;
+import oasis.piloti.repository.StudyCardRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyCardService {
+
+    private final StudyCardRepository studyCardRepository;
+
+    public List<StudyCardResponse.SimpleInfoDTO> getStudyCards() {
+        return studyCardRepository.findAll().stream()
+                .map(StudyCardResponse.SimpleInfoDTO::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public StudyCardResponse.InfoDTO getStudyCard(Long studyCardId) {
+        StudyCard studyCard = studyCardRepository.findById(studyCardId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 학습 카드를 찾을 수 없습니다. Id: " + studyCardId));
+        return StudyCardResponse.InfoDTO.fromEntity(studyCard);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #7 

## 📝작업 내용

> Dialogue, StudyCard 엔티티 수정

- Dialogue.java
- koreanText -> koreanSentence 필드 이름 수정
- russianText -> russianSentence 필드 이름 수정

- StudyCard.java
- title -> koreanTitle 필드 이름 수정
- russianTitle 필드 작성
- description -> koreanDescription 필드 이름 수정
- russianDescription 필드 작성

> Word 엔티티 작성

> StudyCardResponse 작성
- 학습 카드 리스트 조회의 응답을 처리하기 위해 SimpleInfoDTO 작성
- 학습 카드 조회의 응답을 처리하기 위해 InfoDTO, WordDTO, DialogueDTO 작성

> StudyCardController, StudyCardService 작성
- 학습 카드 리스트 조회 요청을 처리하기 위해 getStudyCards() 작성
- 학습 카드 조회 요청을 처리하기 위해 getStudyCard() 작성

> StudyCardRepository, WordRepository, DialogueRepository 작성

> DataInitializer 작성
- 초기 테스트 데이터 구축을 위한 DataInitializer 작성

