### PR TITLE
[Feat/#9] 발음 평가 기능 구현

### DIFF
--- a/src/main/java/oasis/piloti/config/RestTemplateConfig.java
+++ b/src/main/java/oasis/piloti/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package oasis.piloti.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/oasis/piloti/controller/PronunciationController.java
+++ b/src/main/java/oasis/piloti/controller/PronunciationController.java
@@ -1,0 +1,29 @@
+package oasis.piloti.controller;
+
+import lombok.RequiredArgsConstructor;
+import oasis.piloti.api.ApiResponse;
+import oasis.piloti.dto.EtriApiResponse;
+import oasis.piloti.service.PronunciationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static oasis.piloti.api.ResponseBuilder.*;
+
+@RestController
+@RequiredArgsConstructor
+public class PronunciationController {
+
+    private final PronunciationService pronunciationService;
+
+    @PostMapping("/api/pronunciation/evaluate")
+    public ResponseEntity<ApiResponse<EtriApiResponse.PronunciationEvaluationDTO>> evaluatePronunciation(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("script") String script) throws Exception {
+
+        EtriApiResponse.PronunciationEvaluationDTO evaluationResult = pronunciationService.evaluatePronunciation(file, script);
+
+        return buildSuccessResponseWithData(evaluationResult, "발음 평가를 성공적으로 완료했습니다.", HttpStatus.OK);
+    }
+}

--- a/src/main/java/oasis/piloti/dto/EtriApiResponse.java
+++ b/src/main/java/oasis/piloti/dto/EtriApiResponse.java
@@ -1,0 +1,60 @@
+package oasis.piloti.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class EtriApiResponse {
+
+    @Getter
+    @NoArgsConstructor
+    public static class PronunciationEvaluationDTO {
+
+        @JsonProperty("result")
+        private int result;
+
+        @JsonProperty("return_object")
+        private EvaluationResultDTO returnObject;
+
+        @Builder
+        public PronunciationEvaluationDTO(int result, EvaluationResultDTO returnObject) {
+            this.result = result;
+            this.returnObject = returnObject;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class EvaluationResultDTO {
+
+        @JsonProperty("recognized")
+        private String recognized;
+
+        @JsonProperty("score")
+        private int score;
+
+        @Builder
+        public EvaluationResultDTO(String recognized, int score) {
+            this.recognized = recognized;
+            this.score = score;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ErrorResponseDTO {
+
+        @JsonProperty("result")
+        private int result;
+
+        @JsonProperty("reason")
+        private String reason;
+
+        @Builder
+        public ErrorResponseDTO(int result, String reason) {
+            this.result = result;
+            this.reason = reason;
+        }
+    }
+}

--- a/src/main/java/oasis/piloti/service/EtriApiService.java
+++ b/src/main/java/oasis/piloti/service/EtriApiService.java
@@ -1,0 +1,72 @@
+package oasis.piloti.service;
+
+import lombok.RequiredArgsConstructor;
+import oasis.piloti.dto.EtriApiResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EtriApiService {
+
+    private static final String ETRI_PRONUNCIATION_API_URL = "http://aiopen.etri.re.kr:8000/WiseASR/Pronunciation";
+
+    // 환경 변수로 등록한 ETRI API 키
+    @Value("${etri.rest.api.key}")
+    private String etriApiKey;
+
+    // ETRI API 호출을 위한 클라이언트 모듈
+    private final RestTemplate restTemplate;
+
+    public EtriApiResponse.PronunciationEvaluationDTO requestPronunciationEvaluation(String script, byte[] audioData) {
+
+        // ETRI API의 URI 가져오기
+        URI uri = UriComponentsBuilder.fromHttpUrl(ETRI_PRONUNCIATION_API_URL).build().encode().toUri();
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, etriApiKey);
+        headers.set(HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8");
+
+        // 요청 본문 데이터 생성
+        Map<String, Object> requestBody = new HashMap<>();
+        Map<String, String> argument = new HashMap<>();
+
+        String audioBase64 = Base64.getEncoder().encodeToString(audioData);
+        argument.put("language_code", "korean");
+        argument.put("script", script);
+        argument.put("audio", audioBase64);
+        requestBody.put("argument", argument);
+
+        // 요청 엔터티 생성
+        HttpEntity<Map<String, Object>> mapHttpEntity = new HttpEntity<>(requestBody, headers);
+
+        // ETRI API 호출 및 응답 받기
+        EtriApiResponse.PronunciationEvaluationDTO response = restTemplate.exchange(
+                uri,
+                HttpMethod.POST,
+                mapHttpEntity,
+                EtriApiResponse.PronunciationEvaluationDTO.class
+        ).getBody();
+
+        // 응답이 null인 경우 예외 처리
+        if (response == null) {
+            throw new RuntimeException("ETRI API 서버에 문제가 있습니다.");
+        }
+
+        // 응답 반환
+        return response;
+    }
+}

--- a/src/main/java/oasis/piloti/service/PronunciationService.java
+++ b/src/main/java/oasis/piloti/service/PronunciationService.java
@@ -1,0 +1,24 @@
+package oasis.piloti.service;
+
+import lombok.RequiredArgsConstructor;
+import oasis.piloti.dto.EtriApiResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PronunciationService {
+
+    private final EtriApiService etriApiService;
+
+    public EtriApiResponse.PronunciationEvaluationDTO evaluatePronunciation(MultipartFile file, String script) throws Exception {
+
+        // 파일을 바이트 배열로 변환
+        byte[] audioData = file.getBytes();
+
+        // ETRI 발음 평가 API 호출
+        return etriApiService.requestPronunciationEvaluation(script, audioData);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,8 @@ spring:
         format_sql: true
       default_batch_fetch_size: 100
     open-in-view: false
+
+etri:
+  rest:
+    api:
+      key: ${ETRI_REST_API_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9

## 📝작업 내용

> application.yml 작성
- etri rest api key 설정 추가

> RestTemplateConfig 작성
- RestTemplateConfig 설정 클래스 작성

> EtriApiResponse 작성
- 발음 평가 api 응답을 위해 EtriApiResponse 작성

> PronunciationController, PronunciationService, EtriApiService 작성

- PronunciationController.java, PronunciationService.java
- 발음 평가 요청을 처리하기 위해 컨트롤러, 서비스 작성

- EtriApiService.java
- etri api 를 호출하기 위해 EtriApiService 작성